### PR TITLE
Python runtime and library updates

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
     
     - name: Install dependencies

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=75.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,31 +10,33 @@ authors = [
     {name = "uzulla / Junichi Ishida", email = "zishida@gmail.com"},
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = {text = "MIT"}
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "chardet>=5.0.0",
+    "chardet>=5.2.0",
     "watchdog>=6.0.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
-    "ruff>=0.0.1",
-    "mypy>=1.0.0",
+    "pytest>=9.0.0",
+    "pytest-cov>=7.0.0",
+    "ruff>=0.14.0",
+    "mypy>=1.18.0",
 ]
 
 [project.scripts]
 charcle = "charcle.cli:main"
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py311"
 line-length = 100
 
 [tool.ruff.lint]
@@ -49,7 +51,7 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/src/charcle/converter.py
+++ b/src/charcle/converter.py
@@ -7,7 +7,6 @@
 import logging
 import os
 import shutil
-from typing import Optional
 
 from charcle.utils.encoding import convert_encoding, detect_encoding
 from charcle.utils.filesystem import (
@@ -26,12 +25,12 @@ class Converter:
 
     def __init__(
         self,
-        from_encoding: Optional[str] = None,
+        from_encoding: str | None = None,
         to_encoding: str = "utf-8",
-        max_size: Optional[str] = None,
-        exclude_patterns: Optional[list[str]] = None,
+        max_size: str | None = None,
+        exclude_patterns: list[str] | None = None,
         verbose: bool = False,
-        fallback_charset: Optional[str] = None,
+        fallback_charset: str | None = None,
     ):
         """
         コンバーターを初期化します。

--- a/src/charcle/utils/filesystem.py
+++ b/src/charcle/utils/filesystem.py
@@ -9,10 +9,9 @@ import fnmatch
 import os
 import re
 import shutil
-from typing import Optional
 
 
-def is_text_file(file_path: str, max_size: Optional[int] = None) -> bool:
+def is_text_file(file_path: str, max_size: int | None = None) -> bool:
     """
     ファイルがテキストファイルかどうかを判断します。
 

--- a/src/charcle/watcher.py
+++ b/src/charcle/watcher.py
@@ -10,7 +10,7 @@ import os
 import signal
 import threading
 import time
-from typing import Any, Optional
+from typing import Any
 
 from charcle.converter import Converter
 from charcle.utils.encoding import detect_encoding
@@ -64,7 +64,7 @@ class Watcher:
         self.converter = converter
         self.interval = interval
         self.running = False
-        self.thread: Optional[threading.Thread] = None
+        self.thread: threading.Thread | None = None
         self.file_mtimes: dict[str, float] = {}
         self.fallback_files: set[str] = set()  # fallback_charsetで作成されたファイルを追跡
         self.logger = logging.getLogger("charcle")
@@ -196,7 +196,7 @@ class Watcher:
         except Exception as e:
             self.logger.error(f"Error converting {rel_path}: {str(e)}")
 
-    def _determine_encoding(self, src_file: str, rel_path: str) -> Optional[str]:
+    def _determine_encoding(self, src_file: str, rel_path: str) -> str | None:
         """
         ソースファイルのエンコーディングを決定します。
 


### PR DESCRIPTION
- Upgrade Python requirement from >=3.9 to >=3.11
- Update setuptools from >=42 to >=75.0.0
- Update chardet from >=5.0.0 to >=5.2.0 (latest)
- Update pytest from >=7.0.0 to >=9.0.0 (latest)
- Update pytest-cov from >=4.0.0 to >=7.0.0 (latest)
- Update ruff from >=0.0.1 to >=0.14.0 (latest)
- Update mypy from >=1.0.0 to >=1.18.0 (latest)
- Update ruff and mypy target version to py311
- Apply ruff auto-fixes for modern type annotations (Optional[X] -> X | None)
- Add Python 3.11 and 3.12 classifiers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  - Python 要件を 3.11 以上に引き上げました（3.9/3.10 のサポートを削除）。
  - 開発依存関係と一部パッケージの最低バージョンを更新しました。
* **Refactor**
  - 型注釈を最新の構文に置き換え、コードの表記をモダン化しました。
* **CI**
  - GitHub Actions の実行対象 Python バージョンを 3.11/3.12 に絞りました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->